### PR TITLE
[Bugfix] Fix current_tables view for Rails-4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,4 @@ gemfile:
 - gemfiles/Gemfile-rails-3.2.x
 - gemfiles/Gemfile-rails-4.0.x
 - gemfiles/Gemfile-rails-4.1.x
+- gemfiles/Gemfile-rails-4.2.x

--- a/app/views/adhoq/current_tables/index.html.slim
+++ b/app/views/adhoq/current_tables/index.html.slim
@@ -23,7 +23,7 @@ ul.list-unstyled.tables
         tbody
           - ar_class.columns.each do |column|
             tr
-              td.pk.icon= column.primary ? icon_fa('check-circle') : ''
+              td.pk.icon= column.name == ar_class.primary_key ? icon_fa('check-circle') : ''
               td.monospace= column.name
               td= column.type
               td.null.icon= column.null ? '' : icon_fa('check')

--- a/gemfiles/Gemfile-rails-4.2.x
+++ b/gemfiles/Gemfile-rails-4.2.x
@@ -1,0 +1,8 @@
+source 'http://rubygems.org'
+
+gemspec path: '..'
+
+gem 'rails', '~> 4.2.0'
+group :test do
+  gem 'codeclimate-test-reporter', require: false
+end


### PR DESCRIPTION
`column` on Rails-4.2 does not have `primary` method.