### PR TITLE
On the fly storage

### DIFF
--- a/app/controllers/adhoq/executions_controller.rb
+++ b/app/controllers/adhoq/executions_controller.rb
@@ -9,7 +9,11 @@ module Adhoq
     def create
       @execution = current_query.execute!(params[:execution][:report_format])
 
-      redirect_to current_query
+      if @execution.report.on_the_fly?
+        respond_report(@execution.report)
+      else
+        redirect_to current_query
+      end
     end
 
     private

--- a/app/models/adhoq/report.rb
+++ b/app/models/adhoq/report.rb
@@ -12,6 +12,10 @@ module Adhoq
       save!
     end
 
+    def on_the_fly?
+      storage.start_with?(Adhoq::Storage::OnTheFly::PREFIX)
+    end
+
     def available?
       identifier.present? && (storage == Adhoq.current_storage.identifier)
     end

--- a/app/views/adhoq/queries/_query.html.slim
+++ b/app/views/adhoq/queries/_query.html.slim
@@ -31,6 +31,7 @@ section.query
             th.report
         tbody
           - query.executions.recent_first.each do |exec|
+            - next if exec.report.on_the_fly?
             tr[exec]
               td.wip
               td.created_at= exec.created_at.localtime.iso8601

--- a/lib/adhoq/global_variable.rb
+++ b/lib/adhoq/global_variable.rb
@@ -27,6 +27,7 @@ module Adhoq
         case type
         when :local_file then Adhoq::Storage::LocalFile
         when :s3         then Adhoq::Storage::S3
+        when :on_the_fly then Adhoq::Storage::OnTheFly
         else
           raise NotImplementedError
         end

--- a/lib/adhoq/storage.rb
+++ b/lib/adhoq/storage.rb
@@ -3,6 +3,7 @@ module Adhoq
     autoload 'FogStorage', 'adhoq/storage/fog_storage'
     autoload 'LocalFile',  'adhoq/storage/local_file'
     autoload 'S3',         'adhoq/storage/s3'
+    autoload 'OnTheFly',   'adhoq/storage/on_the_fly'
 
     def with_new_identifier(suffix = nil, seed = Time.now)
       dirname, fname_seed = ['%Y-%m-%d', '%H%M%S.%L'].map {|f| seed.strftime(f) }

--- a/lib/adhoq/storage/on_the_fly.rb
+++ b/lib/adhoq/storage/on_the_fly.rb
@@ -1,0 +1,28 @@
+module Adhoq
+  module Storage
+    class OnTheFly
+      PREFIX = 'memory://adhoq-on-the-fly'
+
+      attr_reader :identifier, :reports
+
+      def initialize(id_base = Process.pid)
+        @identifier = "#{PREFIX}-#{id_base}"
+        @reports    = {}
+      end
+
+      def store(suffix = nil, seed = Time.now, &block)
+        Adhoq::Storage.with_new_identifier(suffix, seed) do |identifier|
+          @reports[identifier] = yield.tap(&:rewind)
+        end
+      end
+
+      def get(identifier)
+        if item = @reports.delete(identifier)
+          item.read.tap { item.close }
+        else
+          nil
+        end
+      end
+    end
+  end
+end

--- a/spec/adhoq/storage_spec.rb
+++ b/spec/adhoq/storage_spec.rb
@@ -25,5 +25,19 @@ module Adhoq
 
       specify { expect(storage.get(identifier)).to eq "Hello adhoq!\n" }
     end
+
+    describe Storage::OnTheFly do
+      let(:storage) { Storage::OnTheFly.new }
+
+      let!(:identifier) do
+        storage.store('.txt') { StringIO.new("Hello adhoq!\n") }
+      end
+
+      specify { expect(storage.get(identifier)).to eq "Hello adhoq!\n" }
+
+      specify do
+        expect { storage.get(identifier) }.to change { storage.reports.size }.by(-1)
+      end
+    end
   end
 end

--- a/spec/models/adhoq/execution_spec.rb
+++ b/spec/models/adhoq/execution_spec.rb
@@ -1,7 +1,8 @@
 module Adhoq
   RSpec.describe Execution, :type => :model do
     before do
-      Adhoq.config.storage = :on_the_fly
+      storage = Adhoq::Storage::OnTheFly.new
+      allow(Adhoq).to receive(:current_storage) { storage }
     end
 
     let(:execution) do

--- a/spec/models/adhoq/execution_spec.rb
+++ b/spec/models/adhoq/execution_spec.rb
@@ -1,4 +1,24 @@
 module Adhoq
   RSpec.describe Execution, :type => :model do
+    before do
+      Adhoq.config.storage = :on_the_fly
+    end
+
+    let(:execution) do
+      query = create(:adhoq_query, query: 'SELECT name, description FROM adhoq_queries')
+      query.execute!('xlsx')
+    end
+
+    specify { expect(execution.report).to be_on_the_fly }
+
+    specify 'can get report only on execution' do
+      expect(execution.report.data).to have_values_in_xlsx_sheet([
+        ["name",    "description"],
+        ["A query", "Simple simple SELECT"]
+      ])
+
+      # Accessable only once
+      expect(execution.report.data).to be_nil
+    end
   end
 end


### PR DESCRIPTION
On the fly storage enables

- direct execution -> report download
- work without local directory and S3 bucket

disables

- re-download of an report

Easy to setup and start using