### PR TITLE
[Feature Request] Make changeable query execution target

### DIFF
--- a/app/helpers/adhoq/application_helper.rb
+++ b/app/helpers/adhoq/application_helper.rb
@@ -16,7 +16,8 @@ module Adhoq
       if defined?(ActiveRecord::SchemaMigration)
         ActiveRecord::SchemaMigration.maximum(:version)
       else
-        result = Adhoq::Executor.select("SELECT MAX(version) AS current_version FROM #{ActiveRecord::Migrator.schema_migrations_table_name}")
+        connection = Adhoq::Executor::ConnectionWrapper.new
+        result = connection.select("SELECT MAX(version) AS current_version FROM #{ActiveRecord::Migrator.schema_migrations_table_name}")
         result.rows.first.first
       end
     end

--- a/gemfiles/Gemfile-rails-3.2.x
+++ b/gemfiles/Gemfile-rails-3.2.x
@@ -7,6 +7,8 @@ gem 'rails', '~> 3.2.0'
 gem 'font-awesome-sass', '4.2.0'
 gem 'strong_parameters'
 
+gem 'test-unit'
+
 group :test do
   gem 'codeclimate-test-reporter', require: false
 end

--- a/lib/adhoq.rb
+++ b/lib/adhoq.rb
@@ -14,5 +14,6 @@ module Adhoq
 
   configure do |config|
     config.authorization = proc { true }
+    config.database_connection = proc { ActiveRecord::Base.connection }
   end
 end

--- a/lib/adhoq/configuration.rb
+++ b/lib/adhoq/configuration.rb
@@ -10,6 +10,10 @@ module Adhoq
 
     config_accessor :current_user
 
+    config_accessor :database_connection do
+      -> { ActiveRecord::Base.connection }
+    end
+
     def callablize(name)
       if (c = config[name]).respond_to?(:call)
         c

--- a/lib/adhoq/configuration.rb
+++ b/lib/adhoq/configuration.rb
@@ -10,9 +10,7 @@ module Adhoq
 
     config_accessor :current_user
 
-    config_accessor :database_connection do
-      -> { ActiveRecord::Base.connection }
-    end
+    config_accessor :database_connection
 
     def callablize(name)
       if (c = config[name]).respond_to?(:call)

--- a/lib/adhoq/executor.rb
+++ b/lib/adhoq/executor.rb
@@ -1,42 +1,18 @@
 module Adhoq
   class Executor
-    class << self
-      def select(query)
-        with_sandbox do
-          current_connection.exec_query(query)
-        end
-      end
-
-      def explain(query)
-        with_sandbox do
-          current_connection.explain(query)
-        end
-      end
-
-      def current_connection
-        ActiveRecord::Base.connection
-      end
-
-      def with_sandbox
-        result = nil
-        ActiveRecord::Base.transaction do
-          result = yield
-          raise ActiveRecord::Rollback
-        end
-        result
-      end
-    end
+    autoload 'ConnectionWrapper', 'adhoq/executor/connection_wrapper'
 
     def initialize(query)
+      @connection = ConnectionWrapper.new
       @query = query
     end
 
     def execute
-      wrap_result(self.class.select(@query))
+      wrap_result(@connection.select(@query))
     end
 
     def explain
-      self.class.explain(@query)
+      @connection.explain(@query)
     end
 
     private

--- a/lib/adhoq/executor/connection_wrapper.rb
+++ b/lib/adhoq/executor/connection_wrapper.rb
@@ -1,0 +1,32 @@
+module Adhoq
+  class Executor
+    class ConnectionWrapper
+      attr_reader :connection
+
+      def initialize
+        @connection = Adhoq.config.callablize(:database_connection).call
+      end
+
+      def select(query)
+        with_sandbox do
+          connection.exec_query(query)
+        end
+      end
+
+      def explain(query)
+        with_sandbox do
+          connection.explain(query)
+        end
+      end
+
+      def with_sandbox
+        result = nil
+        connection.transaction do
+          result = yield
+          raise ActiveRecord::Rollback
+        end
+        result
+      end
+    end
+  end
+end

--- a/spec/adhoq/executor/connection_wrapper_spec.rb
+++ b/spec/adhoq/executor/connection_wrapper_spec.rb
@@ -1,0 +1,16 @@
+module Adhoq
+  RSpec.describe Executor::ConnectionWrapper, type: :model do
+    describe '.select' do
+      specify 'Do not reflect write access' do
+        expect {
+          Executor::ConnectionWrapper.new.select(<<-INSERT_SQL.strip_heredoc)
+            INSERT INTO "adhoq_queries"
+            ("description", "name", "query", "updated_at", "created_at")
+            VALUES
+            ("description", "name", "SELECT 1", "NOW", "NOW")
+          INSERT_SQL
+        }.not_to change(Adhoq::Query, :count)
+      end
+    end
+  end
+end

--- a/spec/adhoq/executor_spec.rb
+++ b/spec/adhoq/executor_spec.rb
@@ -7,18 +7,5 @@ module Adhoq
 
       specify { expect(executor.execute).to eq Adhoq::Result.new(%w[answer], [[42]]) }
     end
-
-    describe '.select' do
-      specify 'Do not reflect write access' do
-        expect {
-          Executor.select(<<-INSERT_SQL.strip_heredoc)
-            INSERT INTO "adhoq_queries"
-            ("description", "name", "query", "updated_at", "created_at")
-            VALUES
-            ("description", "name", "SELECT 1", "NOW", "NOW")
-          INSERT_SQL
-        }.not_to change(Adhoq::Query, :count)
-      end
-    end
   end
 end


### PR DESCRIPTION
I want to execute query on different database from `ActiveRecord::Base.connection`.
I propose `Adhoq.config.database_connection`.
Even if database for analyzing is different from production database, We will be able to use `adhoq`

for example

```ruby
Adhoq.configuration do |c|
  c.database_connection = -> { OtherDatabaseModel.connection }
end
```