### PR TITLE
[Feature Request] Implement direct download from S3

### DIFF
--- a/app/controllers/adhoq/executions_controller.rb
+++ b/app/controllers/adhoq/executions_controller.rb
@@ -23,7 +23,11 @@ module Adhoq
     end
 
     def respond_report(report)
-      send_data report.data, type: report.mime_type, filename: report.name, disposition: 'attachment'
+      if Adhoq.current_storage.direct_download?
+        redirect_to report.data_url
+      else
+        send_data report.data, type: report.mime_type, filename: report.name, disposition: 'attachment'
+      end
     end
   end
 end

--- a/app/models/adhoq/report.rb
+++ b/app/models/adhoq/report.rb
@@ -24,6 +24,16 @@ module Adhoq
       storage.get(identifier)
     end
 
+    def data_url(storage = Adhoq.current_storage)
+      storage.get_url(
+        identifier,
+        query: {
+          'response-content-disposition' => "attachment; filename=\"#{name}\"",
+          'response-content-type' => mime_type,
+        }
+      )
+    end
+
     def mime_type
       Adhoq::Reporter.lookup(execution.report_format).mime_type
     end

--- a/lib/adhoq/storage/fog_storage.rb
+++ b/lib/adhoq/storage/fog_storage.rb
@@ -10,6 +10,10 @@ module Adhoq
         end
       end
 
+      def direct_download?
+        false
+      end
+
       def get(identifier)
         get_raw(identifier).body
       end

--- a/lib/adhoq/storage/on_the_fly.rb
+++ b/lib/adhoq/storage/on_the_fly.rb
@@ -16,6 +16,10 @@ module Adhoq
         end
       end
 
+      def direct_download?
+        false
+      end
+
       def get(identifier)
         if item = @reports.delete(identifier)
           item.read.tap { item.close }

--- a/lib/adhoq/storage/s3.rb
+++ b/lib/adhoq/storage/s3.rb
@@ -5,11 +5,20 @@ module Adhoq
     class S3 < FogStorage
       def initialize(bucket, s3_options = {})
         @bucket = bucket
+        @direct_download = s3_options.delete(:direct_download)
         @s3     = Fog::Storage.new({provider: 'AWS'}.merge(s3_options))
+      end
+
+      def direct_download?
+        @direct_download
       end
 
       def identifier
         "s3://#{@bucket}"
+      end
+
+      def get_url(identifier, options = {})
+        get_raw(identifier).url(1.minutes.from_now.to_i, options)
       end
 
       private


### PR DESCRIPTION
If report data is huge, server process consumes much memory and takes a lot of time to download from S3.
This patch allows client user to download directly from S3, via pre-signed url.
pre-signed url is available only for 1 minite.