### PR TITLE
Fix direct s3 download multibyte filename

### DIFF
--- a/app/models/adhoq/report.rb
+++ b/app/models/adhoq/report.rb
@@ -25,13 +25,7 @@ module Adhoq
     end
 
     def data_url(storage = Adhoq.current_storage)
-      storage.get_url(
-        identifier,
-        query: {
-          'response-content-disposition' => "attachment; filename=\"#{name}\"",
-          'response-content-type' => mime_type,
-        }
-      )
+      storage.get_url(self)
     end
 
     def mime_type

--- a/lib/adhoq/storage/fog_storage.rb
+++ b/lib/adhoq/storage/fog_storage.rb
@@ -14,6 +14,10 @@ module Adhoq
         false
       end
 
+      def direct_download_options
+        {}
+      end
+
       def get(identifier)
         get_raw(identifier).body
       end

--- a/lib/adhoq/storage/fog_storage.rb
+++ b/lib/adhoq/storage/fog_storage.rb
@@ -14,10 +14,6 @@ module Adhoq
         false
       end
 
-      def direct_download_options
-        {}
-      end
-
       def get(identifier)
         get_raw(identifier).body
       end

--- a/lib/adhoq/storage/s3.rb
+++ b/lib/adhoq/storage/s3.rb
@@ -37,7 +37,7 @@ module Adhoq
         proc do |report|
           {
             query: {
-              'response-content-disposition' => "attachment; filename=\"#{name}\"",
+              'response-content-disposition' => "attachment; filename*=UTF-8''#{URI.encode_www_form_component(report.name)}",
               'response-content-type' => report.mime_type,
             }
           }


### PR DESCRIPTION
This patch fixes response-content-disposition, because previous format cannot use UTF-8 filename.
 
And, refactor responsibility of parameter options.