### PR TITLE
[Feature] Implement async query execution feature by activejob

### DIFF
--- a/app/controllers/adhoq/executions_controller.rb
+++ b/app/controllers/adhoq/executions_controller.rb
@@ -40,7 +40,7 @@ module Adhoq
     end
 
     def async_execution?
-      defined?(ActiveJob) && Adhoq.config.async_execution && !Adhoq.current_storage.is_a?(Adhoq::Storage::OnTheFly)
+      Adhoq.config.async_execution? && !Adhoq.current_storage.is_a?(Adhoq::Storage::OnTheFly)
     end
   end
 end

--- a/app/controllers/adhoq/executions_controller.rb
+++ b/app/controllers/adhoq/executions_controller.rb
@@ -7,6 +7,12 @@ module Adhoq
     end
 
     def create
+      async_execution? ? asynced_create : synced_create
+    end
+
+    private
+
+    def synced_create
       @execution = current_query.execute!(params[:execution][:report_format])
 
       if @execution.report.on_the_fly?
@@ -16,7 +22,10 @@ module Adhoq
       end
     end
 
-    private
+    def asynced_create
+      Adhoq::ExecuteJob.perform_later(current_query, params[:execution][:report_format])
+      redirect_to current_query
+    end
 
     def current_query
       @query ||= Adhoq::Query.find(params[:query_id])
@@ -28,6 +37,10 @@ module Adhoq
       else
         send_data report.data, type: report.mime_type, filename: report.name, disposition: 'attachment'
       end
+    end
+
+    def async_execution?
+      Adhoq.config.async_execution && !Adhoq.current_storage.is_a?(Adhoq::Storage::OnTheFly)
     end
   end
 end

--- a/app/controllers/adhoq/executions_controller.rb
+++ b/app/controllers/adhoq/executions_controller.rb
@@ -40,7 +40,7 @@ module Adhoq
     end
 
     def async_execution?
-      Adhoq.config.async_execution && !Adhoq.current_storage.is_a?(Adhoq::Storage::OnTheFly)
+      defined?(ActiveJob) && Adhoq.config.async_execution && !Adhoq.current_storage.is_a?(Adhoq::Storage::OnTheFly)
     end
   end
 end

--- a/app/jobs/adhoq/execute_job.rb
+++ b/app/jobs/adhoq/execute_job.rb
@@ -1,9 +1,11 @@
-class Adhoq::ExecuteJob < ActiveJob::Base
-  queue_as do
-    Adhoq.config.job_queue_name.try(:to_sym) || :default
-  end
+if defined?(ActiveJob)
+  class Adhoq::ExecuteJob < ActiveJob::Base
+    queue_as do
+      Adhoq.config.job_queue_name.try(:to_sym) || :default
+    end
 
-  def perform(query, *args)
-    query.execute!(*args)
+    def perform(query, *args)
+      query.execute!(*args)
+    end
   end
 end

--- a/app/jobs/adhoq/execute_job.rb
+++ b/app/jobs/adhoq/execute_job.rb
@@ -1,0 +1,9 @@
+class Adhoq::ExecuteJob < ActiveJob::Base
+  queue_as do
+    Adhoq.config.job_queue_name.try(:to_sym) || :default
+  end
+
+  def perform(query, *args)
+    query.execute!(*args)
+  end
+end

--- a/lib/adhoq/configuration.rb
+++ b/lib/adhoq/configuration.rb
@@ -12,10 +12,8 @@ module Adhoq
 
     config_accessor :database_connection
 
-    if defined?(ActiveJob)
-      config_accessor :async_execution
-      config_accessor :job_queue_name
-    end
+    config_accessor :async_execution
+    config_accessor :job_queue_name
 
     def callablize(name)
       if (c = config[name]).respond_to?(:call)

--- a/lib/adhoq/configuration.rb
+++ b/lib/adhoq/configuration.rb
@@ -12,6 +12,11 @@ module Adhoq
 
     config_accessor :database_connection
 
+    if defined?(ActiveJob)
+      config_accessor :async_execution
+      config_accessor :job_queue_name
+    end
+
     def callablize(name)
       if (c = config[name]).respond_to?(:call)
         c

--- a/lib/adhoq/configuration.rb
+++ b/lib/adhoq/configuration.rb
@@ -22,5 +22,9 @@ module Adhoq
         c.to_proc
       end
     end
+
+    def async_execution?
+      defined?(ActiveJob) && Adhoq.config.async_execution
+    end
   end
 end

--- a/spec/features/execute_adhoc_query_spec.rb
+++ b/spec/features/execute_adhoc_query_spec.rb
@@ -1,15 +1,7 @@
 feature 'Golden-path: execute adhoc query' do
   include FeatureSpecHelper
 
-  scenario 'Visit root, input query and generate report then we get a report' do
-    visit '/adhoq'
-
-    fill_in 'New query', with: 'SELECT * from adhoq_queries'
-
-    click_on 'Explain'
-    click_on 'Refresh'
-    expect(find('.js-explain-result')).to have_content(/SCAN TABLE adhoq_querie/)
-
+  def create_test_query
     fill_in 'New query', with: 'SELECT 42 AS "answer number", "Hello adhoq" AS message'
 
     click_on 'Preview'
@@ -28,6 +20,22 @@ feature 'Golden-path: execute adhoc query' do
     fill_in  'Description', with: 'Description about this query'
 
     click_on 'Save'
+  end
+
+  scenario 'Visit root, input query and click explain then we get a EXPLAIN query result' do
+    visit '/adhoq'
+
+    fill_in 'New query', with: 'SELECT * from adhoq_queries'
+
+    click_on 'Explain'
+    click_on 'Refresh'
+    expect(find('.js-explain-result')).to have_content(/SCAN TABLE adhoq_querie/)
+  end
+
+  scenario 'Visit root, input query and generate report then we get a report' do
+    visit '/adhoq'
+
+    create_test_query
 
     within '.new-execution' do
       select   'xlsx', from: 'Report format'
@@ -43,5 +51,85 @@ feature 'Golden-path: execute adhoc query' do
       ['answer number', 'message'],
       [42.0,            'Hello adhoq']
     ])
+  end
+
+  if defined?(ActiveJob)
+    context "async_execution feature is ON" do
+      around do |ex|
+        current_async_execution = Adhoq.config.async_execution
+        current_active_job_queue_adapter = Adhoq::Engine.config.active_job.queue_adapter
+
+        Adhoq.config.async_execution = true
+        Adhoq::Engine.config.active_job.queue_adapter = :test
+        Adhoq::ExecuteJob.queue_adapter.perform_enqueued_jobs = true
+
+        ex.call
+
+        Adhoq.config.async_execution = current_async_execution
+        Adhoq::Engine.config.active_job.queue_adapter = current_active_job_queue_adapter
+      end
+
+      scenario 'Visit root, input query and generate report then we get a report' do
+        visit '/adhoq'
+
+        create_test_query
+
+        expect {
+          within '.new-execution' do
+            select   'xlsx', from: 'Report format'
+            click_on 'Create report'
+          end
+        }.to change { Adhoq::ExecuteJob.queue_adapter.performed_jobs.size }.from(0).to(1)
+
+        within '.past-executions' do
+          expect(table_contant('table.executions').size).to eq 2
+        end
+
+        # NOTE xlsx parser casts "42" to 42.0
+        expect(Adhoq::Report.order('id DESC').first.data).to have_values_in_xlsx_sheet([
+          ['answer number', 'message'],
+          [42.0,            'Hello adhoq']
+        ])
+      end
+    end
+
+    context "async_execution feature is OFF" do
+      around do |ex|
+        current_async_execution = Adhoq.config.async_execution
+        current_active_job_queue_adapter = Adhoq::Engine.config.active_job.queue_adapter
+
+        Adhoq.config.async_execution = false
+        Adhoq::Engine.config.active_job.queue_adapter = :test
+        Adhoq::ExecuteJob.queue_adapter.perform_enqueued_jobs = true
+
+        ex.call
+
+        Adhoq.config.async_execution = current_async_execution
+        Adhoq::Engine.config.active_job.queue_adapter = current_active_job_queue_adapter
+      end
+
+      scenario 'Visit root, input query and generate report then we get a report' do
+        visit '/adhoq'
+
+        create_test_query
+
+        expect {
+          within '.new-execution' do
+            select   'xlsx', from: 'Report format'
+            click_on 'Create report'
+          end
+        }.not_to change { Adhoq::ExecuteJob.queue_adapter.performed_jobs.size }.from(0)
+
+        within '.past-executions' do
+          expect(table_contant('table.executions').size).to eq 2
+        end
+
+        # NOTE xlsx parser casts "42" to 42.0
+        expect(Adhoq::Report.order('id DESC').first.data).to have_values_in_xlsx_sheet([
+          ['answer number', 'message'],
+          [42.0,            'Hello adhoq']
+        ])
+      end
+    end
   end
 end

--- a/spec/features/execute_adhoc_query_spec.rb
+++ b/spec/features/execute_adhoc_query_spec.rb
@@ -65,6 +65,8 @@ feature 'Golden-path: execute adhoc query' do
 
         ex.call
 
+        Adhoq::ExecuteJob.queue_adapter.performed_jobs.clear
+
         Adhoq.config.async_execution = current_async_execution
         Adhoq::Engine.config.active_job.queue_adapter = current_active_job_queue_adapter
       end
@@ -103,6 +105,8 @@ feature 'Golden-path: execute adhoc query' do
         Adhoq::ExecuteJob.queue_adapter.perform_enqueued_jobs = true
 
         ex.call
+
+        Adhoq::ExecuteJob.queue_adapter.performed_jobs.clear
 
         Adhoq.config.async_execution = current_async_execution
         Adhoq::Engine.config.active_job.queue_adapter = current_active_job_queue_adapter


### PR DESCRIPTION
I often want to execute a long time query.
But current adhoq execution is synchronous, and so HTTP timeout error is occured by long time query.

If adhoq with Rails-4.2.x or later, this patch enable async execution feature.