### PR TITLE
add igonre table config for show#tables

### DIFF
--- a/app/controllers/adhoq/current_tables_controller.rb
+++ b/app/controllers/adhoq/current_tables_controller.rb
@@ -3,11 +3,11 @@ module Adhoq
     before_filter :eager_load_models
 
     def index
-      ignore_table_names = Array(Adhoq.config.ignore_table_names)
-      ignore_table_names << 'ActiveRecord::SchemaMigration'
+      hidden_model_names = Array(Adhoq.config.hidden_model_names)
+      hidden_model_names << 'ActiveRecord::SchemaMigration'
 
       @ar_classes = ActiveRecord::Base.subclasses.
-        reject {|klass| ignore_table_names.include?(klass.name) }.
+        reject {|klass| hidden_model_names.include?(klass.name) }.
         sort_by(&:name)
 
       render layout: false

--- a/app/controllers/adhoq/current_tables_controller.rb
+++ b/app/controllers/adhoq/current_tables_controller.rb
@@ -3,8 +3,11 @@ module Adhoq
     before_filter :eager_load_models
 
     def index
+      ignore_table_names = Array(Adhoq.config.ignore_table_names)
+      ignore_table_names << 'ActiveRecord::SchemaMigration'
+
       @ar_classes = ActiveRecord::Base.subclasses.
-        reject {|klass| klass.name == 'ActiveRecord::SchemaMigration' }.
+        reject {|klass| ignore_table_names.include?(klass.name) }.
         sort_by(&:name)
 
       render layout: false

--- a/lib/adhoq/configuration.rb
+++ b/lib/adhoq/configuration.rb
@@ -11,7 +11,7 @@ module Adhoq
     config_accessor :current_user
 
     config_accessor :database_connection
-    config_accessor :ignore_table_names
+    config_accessor :hidden_model_names
 
     def callablize(name)
       if (c = config[name]).respond_to?(:call)

--- a/lib/adhoq/configuration.rb
+++ b/lib/adhoq/configuration.rb
@@ -11,6 +11,7 @@ module Adhoq
     config_accessor :current_user
 
     config_accessor :database_connection
+    config_accessor :ignore_table_names
 
     def callablize(name)
       if (c = config[name]).respond_to?(:call)

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -10,7 +10,7 @@ Dummy::Application.configure do
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that
   # preloads Rails for running tests, you may have to set it to true.
-  config.eager_load = false
+  config.eager_load = true
 
   # Configure static asset server for tests with Cache-Control for performance.
   config.serve_static_assets  = true

--- a/spec/dummy/config/initializers/adhoq.rb
+++ b/spec/dummy/config/initializers/adhoq.rb
@@ -2,7 +2,7 @@ Adhoq.configure do |c|
   c.authorization      = :adhoq_authorized?
   c.current_user       = :current_user
   c.storage            = [:local_file, Rails.root + "./tmp/adhoq/#{Rails.env}"]
-  c.ignore_table_names = %w(SecretTable)
+  c.hidden_model_names = %w(SecretTable)
 =begin
   # S3 setting example
   c.storage       = [

--- a/spec/dummy/config/initializers/adhoq.rb
+++ b/spec/dummy/config/initializers/adhoq.rb
@@ -1,7 +1,8 @@
 Adhoq.configure do |c|
-  c.authorization = :adhoq_authorized?
-  c.current_user  = :current_user
-  c.storage       = [:local_file, Rails.root + "./tmp/adhoq/#{Rails.env}"]
+  c.authorization      = :adhoq_authorized?
+  c.current_user       = :current_user
+  c.storage            = [:local_file, Rails.root + "./tmp/adhoq/#{Rails.env}"]
+  c.ignore_table_names = %w(SecretTable)
 =begin
   # S3 setting example
   c.storage       = [

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,35 +11,40 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141007052308) do
+ActiveRecord::Schema.define(version: 20150908073801) do
 
-  create_table "adhoq_executions", force: true do |t|
+  create_table "adhoq_executions", force: :cascade do |t|
     t.integer  "query_id",                            null: false
     t.text     "raw_sql",                             null: false
     t.string   "report_format",                       null: false
     t.string   "status",        default: "requested", null: false
     t.text     "log"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                          null: false
+    t.datetime "updated_at",                          null: false
   end
 
-  create_table "adhoq_queries", force: true do |t|
+  create_table "adhoq_queries", force: :cascade do |t|
     t.string   "name"
     t.string   "description"
     t.text     "query"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
   end
 
-  create_table "adhoq_reports", force: true do |t|
+  create_table "adhoq_reports", force: :cascade do |t|
     t.integer  "execution_id", null: false
     t.string   "identifier",   null: false
     t.time     "generated_at", null: false
     t.string   "storage",      null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
   end
 
   add_index "adhoq_reports", ["execution_id"], name: "index_adhoq_reports_on_execution_id"
+
+  create_table "secret_tables", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
 end

--- a/spec/features/show_database_schema_spec.rb
+++ b/spec/features/show_database_schema_spec.rb
@@ -17,6 +17,9 @@ feature 'Can see database schema at editing form' do
         ["description", "string"],
         ["query",       "text"],
       ]
+
+      # NOTE spec/dummy/config/initializers/adhoq.rb:5
+      expect(page).not_to have_text('secret_tables')
     end
   end
 end


### PR DESCRIPTION
I have prepared the settings that you can specify the table name that
you do not want to appear in the table list.

For example,
```
  config.ignore_table_names = %w(SecretTable)
```

The specified table will not appear in the table list.