### PR TITLE
use :on_the_fly, if unset :storage configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Edit initialization file in `config/initializers/adhoq.rb`
 
 ```ruby
 Adhoq.configure do |config|
+  # if not set, use :on_the_fly.(default)
   config.storage       = [:local_file, Rails.root + './path/to/store/report/files']
   config.authorization = ->(controller) { controller.signed_in? }
 end

--- a/lib/adhoq/configuration.rb
+++ b/lib/adhoq/configuration.rb
@@ -3,7 +3,9 @@ module Adhoq
   class Configuration
     include ActiveSupport::Configurable
 
-    config_accessor :storage
+    config_accessor :storage do
+      [:on_the_fly]
+    end
 
     config_accessor :authorization
     config_accessor :authorization_failure_action


### PR DESCRIPTION
What do you think is to provide a default storage?