### PR TITLE
remove define check for ActiveRecord::SchemaMigration

### DIFF
--- a/app/helpers/adhoq/application_helper.rb
+++ b/app/helpers/adhoq/application_helper.rb
@@ -13,13 +13,7 @@ module Adhoq
     end
 
     def schema_version
-      if defined?(ActiveRecord::SchemaMigration)
-        ActiveRecord::SchemaMigration.maximum(:version)
-      else
-        connection = Adhoq::Executor::ConnectionWrapper.new
-        result = connection.select("SELECT MAX(version) AS current_version FROM #{ActiveRecord::SchemaMigration.table_name}")
-        result.rows.first.first
-      end
+      ActiveRecord::SchemaMigration.maximum(:version)
     end
 
     # TODO extract into presenter


### PR DESCRIPTION
SchemaMigration was introduced since 4.0.
https://github.com/esminc/adhoq/pull/131#discussion_r104933425

Now, Adhoq support version over Rails4.0.
So, it is unnecessary check.