### PR TITLE
remove case dividing by ActiveRecord::SchemaMigration

### DIFF
--- a/app/helpers/adhoq/application_helper.rb
+++ b/app/helpers/adhoq/application_helper.rb
@@ -13,13 +13,9 @@ module Adhoq
     end
 
     def schema_version
-      if defined?(ActiveRecord::SchemaMigration)
-        ActiveRecord::SchemaMigration.maximum(:version)
-      else
-        connection = Adhoq::Executor::ConnectionWrapper.new
-        result = connection.select("SELECT MAX(version) AS current_version FROM #{ActiveRecord::SchemaMigration.table_name}")
-        result.rows.first.first
-      end
+      connection = Adhoq::Executor::ConnectionWrapper.new
+      result = connection.select("SELECT MAX(version) AS current_version FROM #{ActiveRecord::SchemaMigration.table_name}")
+      result.rows.first.first
     end
 
     # TODO extract into presenter


### PR DESCRIPTION
SchemaMigration was introduced since 4.0.

Now, Adhoq support version over Rails4.0.
So, it is unnecessary check.

And, I think schema_version should check from Adhoq::ConnectionWrapper.