### PR TITLE
Fix build error on Travis CI

### DIFF
--- a/gemfiles/Gemfile-rails-4.0.x
+++ b/gemfiles/Gemfile-rails-4.0.x
@@ -2,6 +2,19 @@ source 'http://rubygems.org'
 
 gemspec path: '..'
 
+if Gem::Version.create(RUBY_VERSION) < Gem::Version.create('2.3.0')
+  # fog-core 1.44 depends xmlrpc, requires Ruby version >= 2.3.0
+  gem 'fog-core', '< 1.44.0'
+end
+
+if Gem::Version.create(RUBY_VERSION) < Gem::Version.create('2.2.2')
+  # nio4r 2 requires Ruby version >= 2.2.2
+  gem 'nio4r', '< 2.0.0'
+
+  # Rack 2 requires Ruby version >= 2.2.2
+  gem 'rack', '~> 1.5.2'
+end
+
 gem 'rails', '~> 4.0.0'
 gem 'sass-rails', '~> 4.0.0'
 group :test do

--- a/gemfiles/Gemfile-rails-4.1.x
+++ b/gemfiles/Gemfile-rails-4.1.x
@@ -2,6 +2,19 @@ source 'http://rubygems.org'
 
 gemspec path: '..'
 
+if Gem::Version.create(RUBY_VERSION) < Gem::Version.create('2.3.0')
+  # fog-core 1.44 depends xmlrpc, requires Ruby version >= 2.3.0
+  gem 'fog-core', '< 1.44.0'
+end
+
+if Gem::Version.create(RUBY_VERSION) < Gem::Version.create('2.2.2')
+  # nio4r 2 requires Ruby version >= 2.2.2
+  gem 'nio4r', '< 2.0.0'
+
+  # Rack 2 requires Ruby version >= 2.2.2
+  gem 'rack', '~> 1.5.2'
+end
+
 gem 'rails', '~> 4.1.0'
 group :test do
   gem 'codeclimate-test-reporter', require: false

--- a/gemfiles/Gemfile-rails-4.2.x
+++ b/gemfiles/Gemfile-rails-4.2.x
@@ -2,6 +2,19 @@ source 'http://rubygems.org'
 
 gemspec path: '..'
 
+if Gem::Version.create(RUBY_VERSION) < Gem::Version.create('2.3.0')
+  # fog-core 1.44 depends xmlrpc, requires Ruby version >= 2.3.0
+  gem 'fog-core', '< 1.44.0'
+end
+
+if Gem::Version.create(RUBY_VERSION) < Gem::Version.create('2.2.2')
+  # nio4r 2 requires Ruby version >= 2.2.2
+  gem 'nio4r', '< 2.0.0'
+
+  # Rack 2 requires Ruby version >= 2.2.2
+  gem 'rack', '~> 1.6.0'
+end
+
 gem 'rails', '~> 4.2.0'
 group :test do
   gem 'codeclimate-test-reporter', require: false


### PR DESCRIPTION
This PR solved the following dependencies.

- fog-core 1.44 depends xmlrpc, requires Ruby version >= 2.3.0
- nio4r 2 depends xmlrpc, requires Ruby version >= 2.2.2
- Rack 2 requires Ruby version >= 2.2.2

Refer: https://travis-ci.org/esminc/adhoq/builds/227115534