### PR TITLE
Use metagem fog-aws/fog-local to reduce unnecessary dependencies

### DIFF
--- a/adhoq.gemspec
+++ b/adhoq.gemspec
@@ -20,7 +20,8 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'axlsx', '~> 2.0'
   s.add_dependency 'coffee-rails'
-  s.add_dependency 'fog',   '~> 1.23'
+  s.add_dependency 'fog-aws', '~> 1.4'
+  s.add_dependency 'fog-local', '~> 0.3'
   s.add_dependency 'font-awesome-sass', '~> 4.2.0'
   s.add_dependency 'jquery-rails'
   s.add_dependency 'sass-rails'

--- a/lib/adhoq/storage/local_file.rb
+++ b/lib/adhoq/storage/local_file.rb
@@ -1,4 +1,4 @@
-require 'fog'
+require 'fog/local'
 
 module Adhoq
   module Storage

--- a/lib/adhoq/storage/s3.rb
+++ b/lib/adhoq/storage/s3.rb
@@ -1,4 +1,4 @@
-require 'fog'
+require 'fog/aws'
 
 module Adhoq
   module Storage


### PR DESCRIPTION
I've got following message when I add `gem 'adhoq'` to the Gemfile and run `bundle install`.

```
Post-install message from fog:
------------------------------
Thank you for installing fog!

IMPORTANT NOTICE:
If there's a metagem available for your cloud provider, e.g. `fog-aws`,
you should be using it instead of requiring the full fog collection to avoid
unnecessary dependencies.

'fog' should be required explicitly only if:
- The provider you use doesn't yet have a metagem available.
- You require Ruby 1.9.3 support.
------------------------------
```

Notice: I'm not testing in production yet 🙈 