### PR TITLE
Add base_controller configuration

### DIFF
--- a/app/controllers/adhoq/application_controller.rb
+++ b/app/controllers/adhoq/application_controller.rb
@@ -1,5 +1,5 @@
 module Adhoq
-  class ApplicationController < ::ApplicationController
+  class ApplicationController < Adhoq.config.base_controller.constantize
     layout 'adhoq/application'
 
     # NOTE support for before Rails5 application

--- a/lib/adhoq/configuration.rb
+++ b/lib/adhoq/configuration.rb
@@ -7,6 +7,10 @@ module Adhoq
       [:on_the_fly]
     end
 
+    config_accessor :base_controller do
+      'ApplicationController'
+    end
+
     config_accessor :authorization
     config_accessor :authorization_failure_action
 

--- a/spec/dummy/app/controllers/my_application_controller.rb
+++ b/spec/dummy/app/controllers/my_application_controller.rb
@@ -1,4 +1,4 @@
-class ApplicationController < ActionController::Base
+class MyApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception

--- a/spec/dummy/config/initializers/adhoq.rb
+++ b/spec/dummy/config/initializers/adhoq.rb
@@ -1,4 +1,5 @@
 Adhoq.configure do |c|
+  c.base_controller    = 'MyApplicationController'
   c.authorization      = :adhoq_authorized?
   c.current_user       = :current_user
   c.storage            = [:local_file, Rails.root + "./tmp/adhoq/#{Rails.env}"]


### PR DESCRIPTION
Adhoq requires a controller which inherit ActionController::Base.
But in some environment the ApplicationController inherited ActionController::API.
Configurable base_controller helps that situation.