### PR TITLE
Hide model if model is abstract_class

### DIFF
--- a/app/controllers/adhoq/current_tables_controller.rb
+++ b/app/controllers/adhoq/current_tables_controller.rb
@@ -8,7 +8,7 @@ module Adhoq
       hidden_model_names << 'ApplicationRecord'
 
       @ar_classes = ActiveRecord::Base.descendants.
-        reject {|klass| hidden_model_names.include?(klass.name) }.
+        reject {|klass| klass.abstract_class? || hidden_model_names.include?(klass.name) }.
         sort_by(&:name)
 
       render layout: false

--- a/spec/dummy/app/models/abstract_table.rb
+++ b/spec/dummy/app/models/abstract_table.rb
@@ -1,0 +1,3 @@
+class AbstractTable < ActiveRecord::Base
+  self.abstract_class = true
+end


### PR DESCRIPTION
Adhoq reject `abstract_class` based on name which is `ApplicationRecord`, but I have another `abstract_class` `Admin::ApplicationRecord` like following:

```rb
module Admin
  class ApplicationRecord < ActiveRecord::Base
    self.abstract_class = true
  end
end
```

It can be hidden by `config.hidden_model_names`, but it is not convenient.
I added a `abstract_class?` filter for `@ar_classes` setup.