### PR TITLE
Fix ActionView::Template::Error on SQL statement error

### DIFF
--- a/app/views/adhoq/explains/statement_invalid.html.slim
+++ b/app/views/adhoq/explains/statement_invalid.html.slim
@@ -1,5 +1,5 @@
 p.statement-invalid.alert.alert-danger
-  strong= @statement_invalid.original_exception.class
+  strong= @statement_invalid.cause.class
   br
-  = @statement_invalid.original_exception.message
+  = @statement_invalid.cause.message
 

--- a/app/views/adhoq/previews/statement_invalid.html.slim
+++ b/app/views/adhoq/previews/statement_invalid.html.slim
@@ -1,5 +1,5 @@
 p.statement-invalid.alert.alert-danger
-  strong= @statement_invalid.original_exception.class
+  strong= @statement_invalid.cause.class
   br
-  = @statement_invalid.original_exception.message
+  = @statement_invalid.cause.message
 

--- a/spec/features/execute_adhoc_query_spec.rb
+++ b/spec/features/execute_adhoc_query_spec.rb
@@ -86,6 +86,25 @@ feature 'Golden-path: execute adhoc query' do
     ])
   end
 
+  scenario 'Visit root and input invalid query then we get a error message' do
+    visit '/adhoq'
+
+    fill_in 'New query', with: 'SELECT * from adhoq_queries_xxx'
+
+    click_on 'Refresh'
+    expect(find('.js-preview-result')).to have_content(/SQLite3::SQLException/)
+  end
+
+  scenario 'Visit root, input invalid query and click explain then we get a error message' do
+    visit '/adhoq'
+
+    fill_in 'New query', with: 'SELECT * from adhoq_queries_xxx'
+
+    click_on 'Explain'
+    click_on 'Refresh'
+    expect(find('.js-explain-result')).to have_content(/SQLite3::SQLException/)
+  end
+
   if defined?(ActiveJob)
     context "async_execution feature is ON", async_execution: true,  active_job_test_adapter: true do
       scenario 'Visit root, input query and generate report then we get a report' do


### PR DESCRIPTION
Rails 5.1 removed `original_exception` method from ActiveRecord::StatementInvalid so we need to use `cause` method instead.

https://github.com/rails/rails/commit/bc6c5df4699d3f6b4a61dd12328f9e0f1bd6cf46