### PR TITLE
Fix show table feature error(a case where there is an anonymous class  inherited ActiveRecord::Base)

### DIFF
--- a/app/controllers/adhoq/current_tables_controller.rb
+++ b/app/controllers/adhoq/current_tables_controller.rb
@@ -8,7 +8,7 @@ module Adhoq
       hidden_model_names << 'ApplicationRecord'
 
       @ar_classes = ActiveRecord::Base.descendants.
-        reject {|klass| klass.abstract_class? || hidden_model_names.include?(klass.name) }.
+        reject {|klass| klass.abstract_class? || hidden_model_names.include?(klass.name) || klass.name.nil? }.
         sort_by(&:name)
 
       render layout: false


### PR DESCRIPTION
If there is an anonymous class inherited ActiveRecord::Base(e.g. SwitchPoint), the show table feature fails.
Because the name is nil in anonymous classes, it fails sorting by table name.
So I excluded anonymous classes.