### PR TITLE
Searching the descendent table, use ApplicationRecord if it defined

### DIFF
--- a/app/controllers/adhoq/current_tables_controller.rb
+++ b/app/controllers/adhoq/current_tables_controller.rb
@@ -7,7 +7,8 @@ module Adhoq
       hidden_model_names << 'ActiveRecord::SchemaMigration'
       hidden_model_names << 'ApplicationRecord'
 
-      @ar_classes = ActiveRecord::Base.descendants.
+      ar_base_class = defined?(ApplicationRecord) ? ApplicationRecord : ActiveRecord::Base
+      @ar_classes = ar_base_class.descendants.
         reject {|klass| klass.abstract_class? || hidden_model_names.include?(klass.name) || klass.name.nil? }.
         sort_by(&:name)
 


### PR DESCRIPTION
If there is a subclass of ActiveRecord::Base that isn't joined the table(e.g. SwitchPoint), the show table feature fails.
So I fixed to use ApplicationRecord if it was defined.