### PR TITLE
Migrate from FactoryGirl to FactoryBot

### DIFF
--- a/adhoq.gemspec
+++ b/adhoq.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'capybara', '~> 2.4.3'
   s.add_development_dependency 'database_cleaner'
-  s.add_development_dependency 'factory_girl_rails'
+  s.add_development_dependency 'factory_bot_rails'
   s.add_development_dependency 'launchy'
   s.add_development_dependency 'poltergeist', '~> 1.6.0'
   s.add_development_dependency 'pry-byebug'

--- a/spec/factories/adhoq_queries.rb
+++ b/spec/factories/adhoq_queries.rb
@@ -1,6 +1,6 @@
 # Read about factories at https://github.com/thoughtbot/factory_girl
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :adhoq_query, class: 'Adhoq::Query' do
     name        'A query'
     description 'Simple simple SELECT'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ require 'rspec/rails'
 require 'capybara/rspec'
 require 'capybara/poltergeist'
 require 'database_cleaner'
-require 'factory_girl_rails'
+require 'factory_bot_rails'
 require 'pry-byebug'
 
 Rails.backtrace_cleaner.remove_silencers!
@@ -36,7 +36,7 @@ RSpec.configure do |config|
   config.profile_examples = 10
   config.order = :random
 
-  config.include FactoryGirl::Syntax::Methods
+  config.include FactoryBot::Syntax::Methods
   Kernel.srand config.seed
 
   config.around(:each, :fog_mock) do |example|


### PR DESCRIPTION
FactoryGirl has been renamed as FactoryBot.
Ref: https://robots.thoughtbot.com/factory_bot

This commit fixes the following warning message:
```
DEPRECATION WARNING: The factory_girl gem is deprecated. Please upgrade to factory_bot.
See https://github.com/thoughtbot/factory_bot/blob/v4.9.0/UPGRADE_FROM_FACTORY_GIRL.md for further instructions.
```