### PR TITLE
Change the dependency condition of axlsx for upgrading axlsx github repository(not rubygems) to version 3

### DIFF
--- a/adhoq.gemspec
+++ b/adhoq.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", ">= 4.0"
 
-  s.add_dependency 'axlsx', '~> 2.0'
+  s.add_dependency 'axlsx', '>= 2.0'
   s.add_dependency 'coffee-rails'
   s.add_dependency 'fog-aws', '~> 1.4'
   s.add_dependency 'fog-local', '~> 0.3'


### PR DESCRIPTION
For upgrading [axlsx](https://github.com/randym/axlsx) gem version of github repository, 
dependency error raise as bundle install.

```
Bundler could not find compatible versions for gem "axlsx":
  In Gemfile:
    axlsx

    adhoq was resolved to 0.2.0, which depends on
      axlsx (~> 2.0)
...
```
