### PR TITLE
Change the dependency condition of fog-aws

### DIFF
--- a/adhoq.gemspec
+++ b/adhoq.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'axlsx', '>= 2.0'
   s.add_dependency 'coffee-rails'
-  s.add_dependency 'fog-aws', '~> 1.4'
+  s.add_dependency 'fog-aws', '>= 1.4'
   s.add_dependency 'fog-local', '~> 0.3'
   s.add_dependency 'font-awesome-sass', '~> 4.2.0'
   s.add_dependency 'jquery-rails'


### PR DESCRIPTION
For upgrading axlsx gem version of github repository, dependency error raise as bundle install.

```
Bundler could not find compatible versions for gem "fog-aws":
  In snapshot (Gemfile.lock):
    fog-aws (= 2.0.0)

  In Gemfile:
    adhoq was resolved to 0.2.0, which depends on
      fog-aws (~> 1.4)

```