### PR TITLE
allow to hide rows count

### DIFF
--- a/app/views/adhoq/current_tables/index.html.slim
+++ b/app/views/adhoq/current_tables/index.html.slim
@@ -14,7 +14,8 @@ ul.list-unstyled.tables
       table.table.table-striped.table-hover.table-bordered
         caption
           span.name= ar_class.table_name
-          small.count #{ar_class.unscoped.count} rows
+          - unless Adhoq.config.hide_rows_count
+            small.count #{ar_class.unscoped.count} rows
         thead
           tr
             th.col-sm-1.pk PK

--- a/lib/adhoq/configuration.rb
+++ b/lib/adhoq/configuration.rb
@@ -18,6 +18,7 @@ module Adhoq
 
     config_accessor :database_connection
     config_accessor :hidden_model_names
+    config_accessor :hide_rows_count
 
     config_accessor :async_execution
     config_accessor :job_queue_name


### PR DESCRIPTION
current_tables page  execute count query for each all tables.
It's too heavy for some service. So I'd like to disable this feature.
