### PR TITLE
fix N+1 queries for adhoq_reports

### DIFF
--- a/app/views/adhoq/queries/_query.html.slim
+++ b/app/views/adhoq/queries/_query.html.slim
@@ -43,6 +43,6 @@ section.query
           th.status=     human(Adhoq::Execution, :status)
           th.report
       tbody
-        - query.executions.recent_first.each do |exec|
+        - query.executions.recent_first.preload(:report).each do |exec|
           - next if exec.report.try(:on_the_fly?)
           = render 'execution', query: query, exec: exec


### PR DESCRIPTION
`Adhoq::QueriesController#show` execute N+1 queries.

BEFORE

```
Started GET "/adhoq/q/3" for 127.0.0.1 at 2018-08-08 20:07:04 +0900
Processing by Adhoq::QueriesController#show as HTML
  Parameters: {"id"=>"3"}
   (0.3ms)  SET NAMES utf8mb4 COLLATE utf8mb4_bin,  @@SESSION.sql_mode = CONCAT(CONCAT(@@sql_mode, ',STRICT_ALL_TABLES'), ',NO_AUTO_VALUE_ON_ZERO'),  @@SESSION.sql_auto_is_null = 0, @@SESSION.wait_timeout = 2147483
  Adhoq::Query Load (0.3ms)  SELECT  `adhoq_queries`.* FROM `adhoq_queries` WHERE `adhoq_queries`.`id` = 3 LIMIT 1
  Adhoq::Execution Load (0.3ms)  SELECT `adhoq_executions`.* FROM `adhoq_executions` WHERE `adhoq_executions`.`query_id` = 3
  Adhoq::Report Load (0.3ms)  SELECT `adhoq_reports`.* FROM `adhoq_reports` WHERE `adhoq_reports`.`execution_id` IN (4, 5, 6, 10, 13, 15)
  Rendering /Users/yoshimin/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/bundler/gems/adhoq-dd0d4ec760ca/app/views/adhoq/queries/show.html.slim within layouts/adhoq/application
  Adhoq::Query Load (0.3ms)  SELECT `adhoq_queries`.* FROM `adhoq_queries` ORDER BY `adhoq_queries`.updated_at DESC
  Rendered /Users/yoshimin/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/bundler/gems/adhoq-dd0d4ec760ca/app/views/adhoq/queries/_queries.html.slim (9.8ms)
  Adhoq::Execution Load (0.7ms)  SELECT `adhoq_executions`.* FROM `adhoq_executions` WHERE `adhoq_executions`.`query_id` = 3 ORDER BY `adhoq_executions`.updated_at DESC
  Adhoq::Report Load (0.4ms)  SELECT  `adhoq_reports`.* FROM `adhoq_reports` WHERE `adhoq_reports`.`execution_id` = 15 LIMIT 1
  Rendered /Users/yoshimin/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/bundler/gems/adhoq-dd0d4ec760ca/app/views/adhoq/queries/_execution.html.slim (10.0ms)
  Adhoq::Report Load (0.5ms)  SELECT  `adhoq_reports`.* FROM `adhoq_reports` WHERE `adhoq_reports`.`execution_id` = 13 LIMIT 1
  Rendered /Users/yoshimin/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/bundler/gems/adhoq-dd0d4ec760ca/app/views/adhoq/queries/_execution.html.slim (0.9ms)
  Adhoq::Report Load (0.4ms)  SELECT  `adhoq_reports`.* FROM `adhoq_reports` WHERE `adhoq_reports`.`execution_id` = 10 LIMIT 1
  Rendered /Users/yoshimin/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/bundler/gems/adhoq-dd0d4ec760ca/app/views/adhoq/queries/_execution.html.slim (1.0ms)
  Adhoq::Report Load (0.4ms)  SELECT  `adhoq_reports`.* FROM `adhoq_reports` WHERE `adhoq_reports`.`execution_id` = 6 LIMIT 1
  Rendered /Users/yoshimin/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/bundler/gems/adhoq-dd0d4ec760ca/app/views/adhoq/queries/_execution.html.slim (0.9ms)
  Adhoq::Report Load (0.3ms)  SELECT  `adhoq_reports`.* FROM `adhoq_reports` WHERE `adhoq_reports`.`execution_id` = 5 LIMIT 1
  Rendered /Users/yoshimin/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/bundler/gems/adhoq-dd0d4ec760ca/app/views/adhoq/queries/_execution.html.slim (0.7ms)
  Adhoq::Report Load (0.3ms)  SELECT  `adhoq_reports`.* FROM `adhoq_reports` WHERE `adhoq_reports`.`execution_id` = 4 LIMIT 1
  Rendered /Users/yoshimin/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/bundler/gems/adhoq-dd0d4ec760ca/app/views/adhoq/queries/_execution.html.slim (0.8ms)
  Rendered /Users/yoshimin/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/bundler/gems/adhoq-dd0d4ec760ca/app/views/adhoq/queries/_query.html.slim (560.8ms)
  Rendered /Users/yoshimin/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/bundler/gems/adhoq-dd0d4ec760ca/app/views/adhoq/queries/show.html.slim within layouts/adhoq/application (597.8ms)
  Rendered /Users/yoshimin/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/bundler/gems/adhoq-dd0d4ec760ca/app/views/adhoq/application/_global_nav.html.slim (5.1ms)
Completed 200 OK in 9715ms (Views: 9581.9ms | ActiveRecord: 8.4ms)
```

AFTER

```
Started GET "/adhoq/q/3" for 127.0.0.1 at 2018-08-08 20:11:05 +0900
Processing by Adhoq::QueriesController#show as HTML
  Parameters: {"id"=>"3"}
   (0.6ms)  SET NAMES utf8mb4 COLLATE utf8mb4_bin,  @@SESSION.sql_mode = CONCAT(CONCAT(@@sql_mode, ',STRICT_ALL_TABLES'), ',NO_AUTO_VALUE_ON_ZERO'),  @@SESSION.sql_auto_is_null = 0, @@SESSION.wait_timeout = 2147483
  Adhoq::Query Load (0.4ms)  SELECT  `adhoq_queries`.* FROM `adhoq_queries` WHERE `adhoq_queries`.`id` = 3 LIMIT 1
  Rendering /Users/yoshimin/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/bundler/gems/adhoq-9f1c8215c718/app/views/adhoq/queries/show.html.slim within layouts/adhoq/application
  Adhoq::Query Load (0.5ms)  SELECT `adhoq_queries`.* FROM `adhoq_queries` ORDER BY `adhoq_queries`.updated_at DESC
  Rendered /Users/yoshimin/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/bundler/gems/adhoq-9f1c8215c718/app/views/adhoq/queries/_queries.html.slim (14.4ms)
  Adhoq::Execution Load (0.6ms)  SELECT `adhoq_executions`.* FROM `adhoq_executions` WHERE `adhoq_executions`.`query_id` = 3 ORDER BY `adhoq_executions`.updated_at DESC
  Adhoq::Report Load (0.3ms)  SELECT `adhoq_reports`.* FROM `adhoq_reports` WHERE `adhoq_reports`.`execution_id` IN (15, 13, 10, 6, 5, 4)
  Rendered /Users/yoshimin/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/bundler/gems/adhoq-9f1c8215c718/app/views/adhoq/queries/_execution.html.slim (10.7ms)
  Rendered /Users/yoshimin/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/bundler/gems/adhoq-9f1c8215c718/app/views/adhoq/queries/_execution.html.slim (1.1ms)
  Rendered /Users/yoshimin/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/bundler/gems/adhoq-9f1c8215c718/app/views/adhoq/queries/_execution.html.slim (0.9ms)
  Rendered /Users/yoshimin/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/bundler/gems/adhoq-9f1c8215c718/app/views/adhoq/queries/_execution.html.slim (1.6ms)
  Rendered /Users/yoshimin/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/bundler/gems/adhoq-9f1c8215c718/app/views/adhoq/queries/_execution.html.slim (0.8ms)
  Rendered /Users/yoshimin/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/bundler/gems/adhoq-9f1c8215c718/app/views/adhoq/queries/_execution.html.slim (0.9ms)
  Rendered /Users/yoshimin/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/bundler/gems/adhoq-9f1c8215c718/app/views/adhoq/queries/_query.html.slim (633.5ms)
  Rendered /Users/yoshimin/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/bundler/gems/adhoq-9f1c8215c718/app/views/adhoq/queries/show.html.slim within layouts/adhoq/application (690.5ms)
  Rendered /Users/yoshimin/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/bundler/gems/adhoq-9f1c8215c718/app/views/adhoq/application/_global_nav.html.slim (3.8ms)
Completed 200 OK in 11406ms (Views: 11346.0ms | ActiveRecord: 6.4ms)
```