### PR TITLE
drop support below ruby 2.3 and test with Rails 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: ruby
 sudo: false
 rvm:
-- 2.1
-- 2.2.9
 - 2.3.6
-- 2.4.3
-- 2.5.0
+- 2.4.4
+- 2.5.1
 - ruby-head
 cache: bundler
 before_install:
@@ -21,26 +19,29 @@ gemfile:
 - gemfiles/Gemfile-rails-4.2.x
 - gemfiles/Gemfile-rails-5.0.x
 - gemfiles/Gemfile-rails-5.1.x
+- gemfiles/Gemfile-rails-5.2.x
 - gemfiles/Gemfile-rails-edge
 matrix:
   exclude:
-    - rvm: 2.1
+    - rvm: 2.3.6
+      gemfile: gemfiles/Gemfile-rails-5.2.x
+    - rvm: 2.3.6
       gemfile: gemfiles/Gemfile-rails-5.1.x
-    - rvm: 2.1
+    - rvm: 2.3.6
       gemfile: gemfiles/Gemfile-rails-5.0.x
-    - rvm: 2.1
+    - rvm: 2.3.6
       gemfile: gemfiles/Gemfile-rails-edge
-    - rvm: 2.4.3
+    - rvm: 2.4.4
       gemfile: gemfiles/Gemfile-rails-4.0.x
-    - rvm: 2.4.3
+    - rvm: 2.4.4
       gemfile: gemfiles/Gemfile-rails-4.1.x
-    - rvm: 2.4.3
+    - rvm: 2.4.4
       gemfile: gemfiles/Gemfile-rails-4.2.x
-    - rvm: 2.5.0
+    - rvm: 2.5.1
       gemfile: gemfiles/Gemfile-rails-4.0.x
-    - rvm: 2.5.0
+    - rvm: 2.5.1
       gemfile: gemfiles/Gemfile-rails-4.1.x
-    - rvm: 2.5.0
+    - rvm: 2.5.1
       gemfile: gemfiles/Gemfile-rails-4.2.x
   allow_failures:
       - rvm: ruby-head

--- a/gemfiles/Gemfile-rails-5.2.x
+++ b/gemfiles/Gemfile-rails-5.2.x
@@ -1,0 +1,9 @@
+source 'http://rubygems.org'
+
+gemspec path: '..'
+
+gem 'rails', '~> 5.2.0'
+gem 'sass-rails', '~> 5.0.0'
+group :test do
+  gem 'codeclimate-test-reporter', require: false
+end


### PR DESCRIPTION
ruby 2.2 is EOL https://www.ruby-lang.org/ja/news/2017/12/14/ruby-2-2-9-released/

And current test matrix failed by this. 

https://travis-ci.org/esminc/adhoq/jobs/413525036
```
Gem::RuntimeRequirementNotMetError: byebug requires Ruby version >= 2.2.0. The
current ruby version is 2.1.0.
An error occurred while installing byebug (10.0.2), and Bundler
```

and Rails 5.2 is already released https://weblog.rubyonrails.org/2018/8/7/Rails-5-2-1-has-been-released/
