### PR TITLE
Fix exexution failure handling

### DIFF
--- a/app/models/adhoq/execution.rb
+++ b/app/models/adhoq/execution.rb
@@ -11,6 +11,7 @@ module Adhoq
       build_report.generate!
       update_attributes(status: :success)
     rescue
+      self.report = nil
       update_attributes(status: :failure)
     end
 

--- a/app/models/adhoq/execution.rb
+++ b/app/models/adhoq/execution.rb
@@ -10,7 +10,8 @@ module Adhoq
     def generate_report!
       build_report.generate!
       update_attributes(status: :success)
-    rescue
+    rescue => e
+      Rails.logger.error(e)
       self.report = nil
       update_attributes(status: :failure)
     end

--- a/spec/models/adhoq/execution_spec.rb
+++ b/spec/models/adhoq/execution_spec.rb
@@ -21,5 +21,23 @@ module Adhoq
       # Accessable only once
       expect(execution.report.data).to be_nil
     end
+
+    describe '#generate_report!' do
+      subject { -> { execution.generate_report! } }
+
+      let(:execution) { Execution.new(query: query, raw_sql: query.query, report_format: 'csv') }
+
+      context 'when execute query successfully' do
+        let(:query) { create(:adhoq_query, query: 'SELECT name, description FROM adhoq_queries') }
+
+        it { is_expected.to change { execution.status }.to('success') }
+      end
+
+      context 'when execute query failed' do
+        let(:query) { create(:adhoq_query, query: 'INVALID SQL') }
+
+        it { is_expected.to change { execution.status }.to('failure') }
+      end
+    end
   end
 end


### PR DESCRIPTION
When query is invalid and it ran failure, it got error with ActiveRecord::NotNullViolation

```                                                                                                                                                                                                                                              Failures

1) Adhoq::Execution#generate_report! when execute query failed should change `execution.status` to "failure"
   Failure/Error: update_attributes(status: :failure)
   ActiveRecord::NotNullViolation:
      SQLite3::ConstraintException: NOT NULL constraint failed: adhoq_reports.identifier: INSERT INTO "adhoq_reports" ("execution_id", "created_at", "updated_at") VALUES (?, ?, ?) 
# ./app/models/adhoq/execution.rb:14:in `rescue in generate_report!'                                                     
# ./app/models/adhoq/execution.rb:11:in `generate_report!'                                                                                                                                            # ./spec/models/adhoq/execution_spec.rb:26:in `block (4 levels) in <module:Adhoq>'
# ------------------
# --- Caused by: ---
# SQLite3::SQLException
   #   near "INVALID": syntax error                                                                                                                                                                                                              #   ./lib/adhoq/executor/connection_wrapper.rb:12:in `block in select'
```


