### PR TITLE
ConnectionWrapperのSQL実行時にconnectionのscopeを限定する

### DIFF
--- a/lib/adhoq/executor/connection_wrapper.rb
+++ b/lib/adhoq/executor/connection_wrapper.rb
@@ -1,29 +1,33 @@
 module Adhoq
   class Executor
     class ConnectionWrapper
-      attr_reader :connection
-
       def initialize
-        @connection = Adhoq.config.callablize(:database_connection).call
       end
 
       def select(query)
-        with_sandbox do
+        with_sandbox do |connection|
           connection.exec_query(query)
         end
       end
 
       def explain(query)
-        with_sandbox do
+        with_sandbox do |connection|
           connection.explain(query)
         end
       end
 
+      def with_connection
+        connection = Adhoq.config.callablize(:database_connection).call
+        yield(connection)
+      end
+
       def with_sandbox
         result = nil
-        connection.transaction do
-          result = yield
-          raise ActiveRecord::Rollback
+        with_connection do |connection|
+          connection.transaction do
+            result = yield(connection)
+            raise ActiveRecord::Rollback
+          end
         end
         result
       end


### PR DESCRIPTION
Executorのattributeとしてconnectionを持ってしまうと、いつ開放されるかを外部から制御しにくいためconnectionを確保して実行するところまでを責務としてしまった方が拡張しやすくてよいと感じました。

背景としては、 http://walf443.hatenablog.com/entry/2018/08/08/230256 といった感じです。

