### PR TITLE
added cache storage

### DIFF
--- a/lib/adhoq/global_variable.rb
+++ b/lib/adhoq/global_variable.rb
@@ -28,6 +28,7 @@ module Adhoq
         when :local_file then Adhoq::Storage::LocalFile
         when :s3         then Adhoq::Storage::S3
         when :on_the_fly then Adhoq::Storage::OnTheFly
+        when :cache      then Adhoq::Storage::Cache
         else
           raise NotImplementedError
         end

--- a/lib/adhoq/storage.rb
+++ b/lib/adhoq/storage.rb
@@ -4,6 +4,7 @@ module Adhoq
     autoload 'LocalFile',  'adhoq/storage/local_file'
     autoload 'S3',         'adhoq/storage/s3'
     autoload 'OnTheFly',   'adhoq/storage/on_the_fly'
+    autoload 'Cache',      'adhoq/storage/cache'
 
     def with_new_identifier(suffix = nil, seed = Time.now)
       dirname, fname_seed = ['%Y-%m-%d', '%H%M%S.%L'].map {|f| seed.strftime(f) }

--- a/lib/adhoq/storage/cache.rb
+++ b/lib/adhoq/storage/cache.rb
@@ -1,0 +1,27 @@
+module Adhoq
+  module Storage
+    class Cache
+      attr_reader :identifier
+
+      def initialize(cache, prefix = "", expire = 300)
+        @cache = cache
+        @identifier = @prefix = prefix
+        @expire = expire
+      end
+
+      def store(suffix = nil, seed = Time.now, &block)
+        Adhoq::Storage.with_new_identifier(suffix, seed) do |identifier|
+          @cache.write(@prefix + identifier, yield.read, expires_in: @expire)
+        end
+      end
+
+      def direct_download?
+        false
+      end
+
+      def get(identifier)
+        @cache.read(@prefix + identifier)
+      end
+    end
+  end
+end


### PR DESCRIPTION

```
# config/initializer/adhoq.rb

Adhoq.configure do |config|
    config.storage = [:cache, Rails.cache, 'adhoq:']
end
```

OnTheFlyのように実行結果が一定期間経つと消えてよいが、複数のアプリケーションサーバーがあると結果を取得できるかわからないといった点がめんどうなので、Rails.cacheに保存できるAdhoq::Storage::Cache を書きました。

