### PR TITLE
fixed sqlite3 activation error.

### DIFF
--- a/adhoq.gemspec
+++ b/adhoq.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'capybara', '~> 2.4.3'
   s.add_development_dependency 'database_cleaner'
-  s.add_development_dependency 'factory_bot_rails'
+  s.add_development_dependency 'factory_bot_rails', '~> 4.11.1'
   s.add_development_dependency 'launchy'
   s.add_development_dependency 'poltergeist', '~> 1.6.0'
   s.add_development_dependency 'pry-byebug'

--- a/adhoq.gemspec
+++ b/adhoq.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry-byebug'
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'simple_xlsx_reader'
-  s.add_development_dependency 'sqlite3'
+  s.add_development_dependency 'sqlite3', '~> 1.3.6'
   s.add_development_dependency 'tapp'
 
   s.test_files = Dir['spec/{adhoq,factories,models,support}/**/*', 'spec/spec_helper.rb']


### PR DESCRIPTION

It got some errors on tests except using Gemfile-rails-edge followings:

```
Gem::LoadError: can't activate sqlite3 (~> 1.3.6), already activated sqlite3-1.4.0. Make sure all dependencies are added to Gemfile.
```

https://travis-ci.org/esminc/adhoq/jobs/511830967 on https://github.com/esminc/adhoq/pull/166

It seems that sqlite3 gem v1.4.0 released with breaking changes.

see also https://qiita.com/Kta-M/items/254a1ba141827a989cb7
