### PR TITLE
support FactoryBot v5

### DIFF
--- a/adhoq.gemspec
+++ b/adhoq.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'capybara', '~> 2.4.3'
   s.add_development_dependency 'database_cleaner'
-  s.add_development_dependency 'factory_bot_rails', '~> 4.11.1'
+  s.add_development_dependency 'factory_bot_rails'
   s.add_development_dependency 'launchy'
   s.add_development_dependency 'poltergeist', '~> 1.6.0'
   s.add_development_dependency 'pry-byebug'

--- a/adhoq.gemspec
+++ b/adhoq.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'capybara', '~> 2.4.3'
   s.add_development_dependency 'database_cleaner'
-  s.add_development_dependency 'factory_bot_rails'
+  s.add_development_dependency 'factory_bot_rails', '~> 4.11.1'
   s.add_development_dependency 'launchy'
   s.add_development_dependency 'poltergeist', '~> 1.6.0'
   s.add_development_dependency 'pry-byebug'

--- a/adhoq.gemspec
+++ b/adhoq.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry-byebug'
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'simple_xlsx_reader'
-  s.add_development_dependency 'sqlite3'
+  s.add_development_dependency 'sqlite3', '~> 1.3.6'
   s.add_development_dependency 'tapp'
 
   s.test_files = Dir['spec/{adhoq,factories,models,support}/**/*', 'spec/spec_helper.rb']

--- a/spec/factories/adhoq_queries.rb
+++ b/spec/factories/adhoq_queries.rb
@@ -2,14 +2,14 @@
 
 FactoryBot.define do
   factory :adhoq_query, class: 'Adhoq::Query' do
-    name        'A query'
-    description 'Simple simple SELECT'
-    query       'SELECT 1'
+    name        { 'A query' }
+    description { 'Simple simple SELECT' }
+    query       { 'SELECT 1' }
 
     trait :complex do
-      name        'adhoq current use'
-      description 'Simple analysys: count execution per query'
-      query <<-SQL.strip_heredoc
+      name        { 'adhoq current use' }
+      description { 'Simple analysys: count execution per query' }
+      query { <<-SQL.strip_heredoc }
         SELECT
           q.id
          ,q.name
@@ -27,9 +27,9 @@ FactoryBot.define do
     end
 
     trait :greeting do
-      name        'greeting'
-      description 'Static query for testing data'
-      query       'SELECT "hello" AS name ,"English greeting message" AS description'
+      name        { 'greeting' }
+      description { 'Static query for testing data' }
+      query       { 'SELECT "hello" AS name ,"English greeting message" AS description' }
     end
   end
 end


### PR DESCRIPTION
This fix is based on #167 

This fixed to unlock factory_bot gem's version.

These error cased by depcatation of static attributes

https://github.com/thoughtbot/factory_bot/releases/tag/v5.0.0 
> Removed: static attributes (use dynamic attributes with a block instead)
