### PR TITLE
fix sass loading error

### DIFF
--- a/gemfiles/Gemfile-rails-5.1.x
+++ b/gemfiles/Gemfile-rails-5.1.x
@@ -3,7 +3,6 @@ source 'http://rubygems.org'
 gemspec path: '..'
 
 gem 'rails', '~> 5.1.2'
-gem 'sass-rails', '~> 5.0.0'
 group :test do
   gem 'codeclimate-test-reporter', require: false
 end

--- a/gemfiles/Gemfile-rails-5.2.x
+++ b/gemfiles/Gemfile-rails-5.2.x
@@ -3,7 +3,6 @@ source 'http://rubygems.org'
 gemspec path: '..'
 
 gem 'rails', '~> 5.2.0'
-gem 'sass-rails', '~> 5.0.0'
 group :test do
   gem 'codeclimate-test-reporter', require: false
 end

--- a/gemfiles/Gemfile-rails-edge
+++ b/gemfiles/Gemfile-rails-edge
@@ -10,7 +10,6 @@ gemspec path: '..'
 gem 'rails', github: 'rails/rails'
 gem 'rack', github: 'rack/rack'
 gem 'arel', github: 'rails/arel'
-gem 'sass-rails', github: 'rails/sass-rails'
 group :test do
   gem 'codeclimate-test-reporter', require: false
 end

--- a/lib/adhoq/engine.rb
+++ b/lib/adhoq/engine.rb
@@ -3,6 +3,7 @@ require 'font-awesome-sass'
 require 'jquery-rails'
 require 'slim-rails'
 require 'active_decorator'
+require 'sassc-rails'
 
 module Adhoq
   class Engine < ::Rails::Engine


### PR DESCRIPTION
This PR is regression of #166.
I'm sorry for that.

```
$ cd spec/dummy
$ bundle exec rails server
```

and go http://localhost:3000/adhoq/

I got

```
LoadError (cannot load such file -- sass):

activesupport (5.2.3) lib/active_support/dependencies.rb:291:in `require'
activesupport (5.2.3) lib/active_support/dependencies.rb:291:in `block in require'
activesupport (5.2.3) lib/active_support/dependencies.rb:257:in `load_dependency'
activesupport (5.2.3) lib/active_support/dependencies.rb:291:in `require'
sprockets (3.7.2) lib/sprockets/autoload/sass.rb:1:in `<top (required)>'
activesupport (5.2.3) lib/active_support/dependencies.rb:291:in `require'
activesupport (5.2.3) lib/active_support/dependencies.rb:291:in `block in require'
activesupport (5.2.3) lib/active_support/dependencies.rb:257:in `load_dependency'
activesupport (5.2.3) lib/active_support/dependencies.rb:291:in `require'
sprockets (3.7.2) lib/sprockets/sass_processor.rb:47:in `initialize'
sprockets (3.7.2) lib/sprockets/sass_processor.rb:26:in `new'
sprockets (3.7.2) lib/sprockets/sass_processor.rb:26:in `instance'
sprockets (3.7.2) lib/sprockets/sass_processor.rb:34:in `cache_key'
sprockets (3.7.2) lib/sprockets/processor_utils.rb:93:in `processor_cache_key'
sprockets (3.7.2) lib/sprockets/cached_environment.rb:22:in `block in initialize'
sprockets (3.7.2) lib/sprockets/cached_environment.rb:53:in `processor_cache_key'
sprockets (3.7.2) lib/sprockets/processor_utils.rb:102:in `block in processors_cache_keys'
sprockets (3.7.2) lib/sprockets/processor_utils.rb:102:in `map'
sprockets (3.7.2) lib/sprockets/processor_utils.rb:102:in `processors_cache_keys'
sprockets (3.7.2) lib/sprockets/processing.rb:159:in `resolve_processors_cache_key_uri'
```

