### PR TITLE
fix Dangerous query method warnings

### DIFF
--- a/app/models/adhoq/time_based_orders.rb
+++ b/app/models/adhoq/time_based_orders.rb
@@ -3,7 +3,7 @@ module Adhoq
     extend ActiveSupport::Concern
 
     included do
-      scope :recent_first, -> { order("#{quoted_table_name}.updated_at DESC") }
+      scope :recent_first, -> { order(arel_table[:updated_at].desc) }
     end
   end
 end


### PR DESCRIPTION
This PR fix following warnings:

```
DEPRECATION WARNING: Dangerous query method (method whose arguments are used as raw SQL) called with non-attribute argument(s): "\"adhoq_queries\".updated_at DESC". Non-attribute arguments will be disallowed in Rails 6.0.
This method should not be called with user-provided values, such as request parameters or model attributes. Known-safe values can be passed by wrapping them in Arel.sql(). (called from block (2 levels) in <module:TimeBasedOrders> at /User
s/yoshimin/src/github.com/esminc/adhoq/app/models/adhoq/time_based_orders.rb:6)
```

This behaviour introduced since Rails 5.2.0.
https://github.com/rails/rails/blob/5-2-stable/activerecord/CHANGELOG.md
> Require raw SQL fragments to be explicitly marked when used in relation query methods.
> Before:
> 
> Article.order("LENGTH(title)")
> After:
> 
> Article.order(Arel.sql("LENGTH(title)"))
> This prevents SQL injection if applications use the [strongly discouraged] form > Article.order(params[:my_order]), under the mistaken belief that only column names will be accepted.
> 
> Raw SQL strings will now cause a deprecation warning, which will become an UnknownAttributeReference error in Rails 6.0. Applications can opt in to the future behavior by setting allow_unsafe_raw_sql to :disabled.
> 
> Common and judged-safe string values (such as simple column references) are unaffected:
> 
> Article.order("title DESC")
