### PR TITLE
fix sqlite type conversion warnings

### DIFF
--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -51,6 +51,8 @@ Dummy::Application.configure do
   # Time columns will become time zone aware in Rails 5.1.
   if  Rails::VERSION::MAJOR >= 5
     config.active_record.time_zone_aware_types = [:datetime, :time]
-    config.active_record.sqlite3.represent_boolean_as_integer = true
+    if  Rails::VERSION::MAJOR > 5 || (Rails::VERSION::MAJOR == 5 && Rails::VERSION::MINOR >= 2)
+      config.active_record.sqlite3.represent_boolean_as_integer = true
+    end
   end
 end

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -51,5 +51,6 @@ Dummy::Application.configure do
   # Time columns will become time zone aware in Rails 5.1.
   if  Rails::VERSION::MAJOR >= 5
     config.active_record.time_zone_aware_types = [:datetime, :time]
+    config.active_record.sqlite3.represent_boolean_as_integer = true
   end
 end


### PR DESCRIPTION
This PR fix following warnings:

```
DEPRECATION WARNING: Leaving `ActiveRecord::ConnectionAdapters::SQLite3Adapter.represent_boolean_as_integer`
set to false is deprecated. SQLite databases have used 't' and 'f' to serialize
boolean values and must have old data converted to 1 and 0 (its native boolean
serialization) before setting this flag to true. Conversion can be accomplished
by setting up a rake task which runs

  ExampleModel.where("boolean_column = 't'").update_all(boolean_column: 1)
  ExampleModel.where("boolean_column = 'f'").update_all(boolean_column: 0)

for all models and all boolean columns, after which the flag must be set to
true by adding the following to your application.rb file:

  Rails.application.config.active_record.sqlite3.represent_boolean_as_integer = true
 (called from <top (required)> at /Users/yoshimin/src/github.com/esminc/adhoq/spec/dummy/config/environment.rb:5)
```
