### PR TITLE
ignore Gemfile.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@ spec/dummy/.sass-cache
 tmp/*
 coverage/*
 gemfiles/*.lock
-./Gemfile.lock
+Gemfile.lock


### PR DESCRIPTION
On my enviroment, Gemfile.lock is not ignored.

```
$ git status
On branch master
Your branch is up to date with 'origin/master'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)

        Gemfile.lock

nothing added to commit but untracked files present (use "git add" to track)
```

```
$ git --version
git version 2.20.1 (Apple Git-117)
```

It seems that ./ is not working on .gitignore

https://git-scm.com/docs/gitignore
