### PR TITLE
adopt Rails6.0.0 rc1

### DIFF
--- a/adhoq.gemspec
+++ b/adhoq.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry-byebug'
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'simple_xlsx_reader'
-  s.add_development_dependency 'sqlite3', '~> 1.3.6'
+  s.add_development_dependency 'sqlite3', '>= 1.4'
   s.add_development_dependency 'tapp'
 
   s.test_files = Dir['spec/{adhoq,factories,models,support}/**/*', 'spec/spec_helper.rb']

--- a/app/controllers/adhoq/queries_controller.rb
+++ b/app/controllers/adhoq/queries_controller.rb
@@ -24,7 +24,7 @@ module Adhoq
 
     def update
       @query = Adhoq::Query.find(params[:id])
-      @query.update_attributes!(query_attributes)
+      @query.update!(query_attributes)
 
       redirect_to @query
     end

--- a/app/models/adhoq/execution.rb
+++ b/app/models/adhoq/execution.rb
@@ -9,11 +9,11 @@ module Adhoq
 
     def generate_report!
       build_report.generate!
-      update_attributes(status: :success)
+      update(status: :success)
     rescue => e
       Rails.logger.error(e)
       self.report = nil
-      update_attributes(status: :failure)
+      update(status: :failure)
     end
 
     def name

--- a/gemfiles/Gemfile-rails-6.0.x
+++ b/gemfiles/Gemfile-rails-6.0.x
@@ -2,7 +2,8 @@ source 'http://rubygems.org'
 
 gemspec path: '..'
 
-gem 'rails', '~> 6.0.0.beta3'
+gem 'rails', '~> 6.0.0.rc1'
+gem 'sqlite3', '>= 1.4'
 group :test do
   gem 'codeclimate-test-reporter', require: false
 end

--- a/gemfiles/Gemfile-rails-6.0.x
+++ b/gemfiles/Gemfile-rails-6.0.x
@@ -3,7 +3,6 @@ source 'http://rubygems.org'
 gemspec path: '..'
 
 gem 'rails', '~> 6.0.0.rc1'
-gem 'sqlite3', '>= 1.4'
 group :test do
   gem 'codeclimate-test-reporter', require: false
 end

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -51,7 +51,7 @@ Dummy::Application.configure do
   # Time columns will become time zone aware in Rails 5.1.
   if  Rails::VERSION::MAJOR >= 5
     config.active_record.time_zone_aware_types = [:datetime, :time]
-    if  Rails::VERSION::MAJOR > 5 || (Rails::VERSION::MAJOR == 5 && Rails::VERSION::MINOR >= 2)
+    if Rails::VERSION::MAJOR == 5 && Rails::VERSION::MINOR == 2
       config.active_record.sqlite3.represent_boolean_as_integer = true
     end
   end


### PR DESCRIPTION
Rails6.0.0rc1 was released.
https://weblog.rubyonrails.org/2019/4/24/Rails-6-0-rc1-released/

