### PR TITLE
Remove old test matrix settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,29 +31,9 @@ matrix:
     - rvm: 2.3.8
       gemfile: gemfiles/Gemfile-rails-5.1.x
     - rvm: 2.3.8
-      gemfile: gemfiles/Gemfile-rails-5.0.x
-    - rvm: 2.3.8
       gemfile: gemfiles/Gemfile-rails-edge
     - rvm: 2.4.6
-      gemfile: gemfiles/Gemfile-rails-4.0.x
-    - rvm: 2.4.6
-      gemfile: gemfiles/Gemfile-rails-4.1.x
-    - rvm: 2.4.6
-      gemfile: gemfiles/Gemfile-rails-4.2.x
-    - rvm: 2.4.6
       gemfile: gemfiles/Gemfile-rails-6.0.x
-    - rvm: 2.5.5
-      gemfile: gemfiles/Gemfile-rails-4.0.x
-    - rvm: 2.5.5
-      gemfile: gemfiles/Gemfile-rails-4.1.x
-    - rvm: 2.5.5
-      gemfile: gemfiles/Gemfile-rails-4.2.x
-    - rvm: 2.6.2
-      gemfile: gemfiles/Gemfile-rails-4.0.x
-    - rvm: 2.6.2
-      gemfile: gemfiles/Gemfile-rails-4.1.x
-    - rvm: 2.6.2
-      gemfile: gemfiles/Gemfile-rails-4.2.x
   allow_failures:
       - rvm: ruby-head
       - gemfile: gemfiles/Gemfile-rails-edge


### PR DESCRIPTION
#169 remove Rails5.1 environement, but other changes introduced again. 