### PR TITLE
fix assets errors in spec

### DIFF
--- a/spec/dummy/app/assets/config/manifest.js
+++ b/spec/dummy/app/assets/config/manifest.js
@@ -1,0 +1,2 @@
+//= link adhoq/application.css
+//= link adhoq/application.js


### PR DESCRIPTION
```
     ActionView::Template::Error:
     Asset `adhoq/application.js` was not declared to be precompiled in production.
     Declare links to your assets in `app/assets/config/manifest.js`.

     //= link adhoq/application.js
     and restart your server
     # ./app/views/layouts/adhoq/app
```