### PR TITLE
remove gem upate system and stop install bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ rvm:
 cache: bundler
 before_install:
 - rvm use @global
-- gem update --system # Need for Ruby 2.5.0. https://github.com/travis-ci/travis-ci/issues/8978
-- gem install --force bundler -v 1.17.3
 before_script:
 - bundle exec rake db:migrate
 env:


### PR DESCRIPTION
fix the following errors

```
bundler's executable "bundle" conflicts with /home/travis/.rvm/rubies/ruby-2.4.9/bin/bundle
Overwrite the executable? [yN]  
No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.
Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received
```