### PR TITLE
Symbolize table_order_key in ApplicationHelper

### DIFF
--- a/app/helpers/adhoq/application_helper.rb
+++ b/app/helpers/adhoq/application_helper.rb
@@ -24,7 +24,7 @@ module Adhoq
     end
 
     def table_order_key(ar_class)
-      ar_class.primary_key || ar_class.columns.first.name
+      (ar_class.primary_key || ar_class.columns.first.name).to_sym
     end
 
     def query_parameter_field(name)


### PR DESCRIPTION
lang: EN
The table `ar_internal_metadata` added in Rails5 has a`key` column as a PRIMARY KEY, and since `KEY` is a reserved word in MySQL 8.0, a SQL Syntax error occurs when the return value of table_order_key is a String.
Fixed to return Symbol so that column names are enclosed in quotes.

lang: JA
Rails5で追加されたテーブル `ar_internal_metadata` は `key` カラムを PRIMARY KEYとして持ち、且つMySQL8.0で`KEY`が予約語となったためtable_order_keyの返り値がStringの場合にSQL Syntaxエラーとなる。
カラム名がクォートで囲まれるようにするためSymbolを返すよう修正した。

String
```
SELECT `ar_internal_metadata`.* FROM `ar_internal_metadata` ORDER BY key LIMIT 1
```

Symbol
```
SELECT `ar_internal_metadata`.* FROM `ar_internal_metadata` ORDER BY `ar_internal_metadata`.`key` ASC LIMIT 1
```
