### PR TITLE
Add csv to gemspec

### DIFF
--- a/adhoq.gemspec
+++ b/adhoq.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rails", ">= 5.1"
 
   s.add_dependency 'caxlsx', '>= 3.0'
+  s.add_dependency 'csv'
   s.add_dependency 'fog-aws', '>= 1.4'
   s.add_dependency 'fog-local', '~> 0.3'
   s.add_dependency 'font-awesome-sass', '>= 4.2'


### PR DESCRIPTION
Since Ruby 3.4, csv is no longer a “default gem” although it is included as a standard library, so I added it to the gemspec.
https://docs.ruby-lang.org/en/3.4/standard_library_md.html